### PR TITLE
Update sorting formats to include "worst".

### DIFF
--- a/docs/advanced-features/filtering-and-sorting-formats-in-yt-dlp.md
+++ b/docs/advanced-features/filtering-and-sorting-formats-in-yt-dlp.md
@@ -28,12 +28,14 @@ yt-dlp -f FILTER URL
 
 #### **Common Filters**
 
-| Filter      | Description                          |
-| ----------- | ------------------------------------ |
-| `best`      | Best quality format (video + audio). |
-| `worst`     | Worst quality format.                |
-| `bestvideo` | Best quality video-only format.      |
-| `bestaudio` | Best quality audio-only format.      |
+| Filter       | Description                          |
+| -----------  | ------------------------------------ |
+| `best`       | Best quality format (video + audio). |
+| `worst`      | Worst quality format.                |
+| `worstvideo` | Worst quality video-only format.     |
+| `worstaudio` | Worst quality audio-only format.     |
+| `bestvideo`  | Best quality video-only format.      |
+| `bestaudio`  | Best quality audio-only format.      |
 
 #### **Advanced Filtering**
 

--- a/docs/advanced-features/format-selection-in-yt-dlp.md
+++ b/docs/advanced-features/format-selection-in-yt-dlp.md
@@ -28,6 +28,8 @@ yt-dlp -F URL
 
 - `best`: Select the best quality format.
 - `worst`: Select the worst quality format.
+- `worstvideo`: Select the worst quality video-only format.
+- `worstaudio`: Select the worst quality audio-only format.
 - `bestvideo`: Select the best quality video-only format.
 - `bestaudio`: Select the best quality audio-only format.
 - `mp4`: Select the best mp4 format.


### PR DESCRIPTION
Source code shows a few more shortcut format selectors. I was looking for "worstaudio" and "worstvideo", so I thought I'd add these to the docs.

Not sure why both `filtering-and-sorting-formats-in-yt-dlp.md` and `format-selection-in-yt-dlp.md` exist - they seem like dupes.

Thanks for these docs!